### PR TITLE
fix bug in lab7 fs building

### DIFF
--- a/user/Makefile
+++ b/user/Makefile
@@ -75,7 +75,9 @@ all: binary pre
 	@$(foreach t, $(CH_TESTS), $(CP) $(TARGET_DIR)/$(t)*.asm $(BUILD_DIR)/asm/;)
     ifneq ($(filter $(CHAPTER), $(HAVE_USERTESTS)),)
 		@cp $(BUILD_DIR)/elf/ch$(CHAPTER)_usertest.elf $(BUILD_DIR)/elf/initproc.elf
+		@cp $(TARGET_DIR)/ch$(CHAPTER)_usertest $(TARGET_DIR)/initproc
     endif
+
 
 clean:
 	@cargo clean


### PR DESCRIPTION
lab7 中 easy-fs-fuse 打包 elf 文件时，会在 /target/riscv64gc-unknown-none-elf/release/ 下寻找，但之前并没有在该路径下生成 initproc 文件。

这个补丁给 makefile 加了一行代码，修复了这个问题。

在我的电脑上测试是有效的，希望助教也测试一下，如果确实有效就merge进主分支，给lab7减少一点坑