### PR TITLE
fix many problems in ch8 testcases, add dup/pipe system call

### DIFF
--- a/user/src/bin/ch4_mmap0.rs
+++ b/user/src/bin/ch4_mmap0.rs
@@ -17,13 +17,13 @@ fn main() -> i32 {
     let prot: usize = 3;
     assert_eq!(len as isize, mmap(start, len, prot));
     for i in start..(start + len) {
-        let mut addr: *mut u8 = i as *mut u8;
+        let addr: *mut u8 = i as *mut u8;
         unsafe {
             *addr = i as u8;
         }
     }
     for i in start..(start + len) {
-        let mut addr: *mut u8 = i as *mut u8;
+        let addr: *mut u8 = i as *mut u8;
         unsafe {
             assert_eq!(*addr, i as u8);
         }

--- a/user/src/bin/ch8_01.rs
+++ b/user/src/bin/ch8_01.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
 extern crate user_lib;
 
 use user_lib::fork;
@@ -11,11 +10,7 @@ const NUM: usize = 10;
 #[no_mangle]
 pub fn main() -> i32 {
     for _ in 0..NUM {
-        let pid = fork();
-        // 应该保证有 initproc 回收 zombie process
-        if pid > 0 {
-            println!("forked new process {}", pid);
-        }
+        fork();
     }
     0
 }

--- a/user/src/bin/ch8_01.rs
+++ b/user/src/bin/ch8_01.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#[macro_use]
 extern crate user_lib;
 
 use user_lib::fork;
@@ -10,7 +11,11 @@ const NUM: usize = 10;
 #[no_mangle]
 pub fn main() -> i32 {
     for _ in 0..NUM {
-        fork();
+        let pid = fork();
+        // 应该保证有 initproc 回收 zombie process
+        if pid > 0 {
+            println!("forked new process {}", pid);
+        }
     }
     0
 }

--- a/user/src/bin/ch8_02.rs
+++ b/user/src/bin/ch8_02.rs
@@ -14,7 +14,7 @@ const LEN: usize = 0x10000;
 pub fn main() -> i32 {
     let prot = 3usize;
     for i in 0..(N * 2) {
-        mmap((UNUSED_START + i * LEN), LEN, prot);
+        mmap(UNUSED_START + i * LEN, LEN, prot);
     }
     0
 }

--- a/user/src/bin/ch8_03.rs
+++ b/user/src/bin/ch8_03.rs
@@ -14,7 +14,7 @@ pub unsafe fn main() -> i32 {
     println!("mmap ...");
     let time: *const TimeVal = (get_pc() + 6) as *mut _;
     raw_sys_gettime(time, 0);
-    let fd = open("fname1-ch8_03", OpenFlags::CREATE | OpenFlags::WRONLY);
+    let fd = open("fname1-ch8_03\0", OpenFlags::CREATE | OpenFlags::WRONLY);
     let stat: *const Stat = (get_pc() + 8) as *mut _;
     raw_sys_fstat(fd as usize, stat);
     read(

--- a/user/src/bin/ch8_04.rs
+++ b/user/src/bin/ch8_04.rs
@@ -10,8 +10,8 @@ use user_lib::{ch8, *};
 #[no_mangle]
 pub unsafe fn main() -> i32 {
     let mut bug: [u8; 200] = [0; 200];
-    open("fname0", OpenFlags::CREATE | OpenFlags::WRONLY);
-    open("fname1", OpenFlags::CREATE | OpenFlags::WRONLY);
+    open("fname0\0", OpenFlags::CREATE | OpenFlags::WRONLY);
+    open("fname1\0", OpenFlags::CREATE | OpenFlags::WRONLY);
     println!("GOOD LUCK");
     read(1, &mut bug);
     write(65537, slice::from_raw_parts_mut(993 as *mut _, 233));
@@ -25,7 +25,7 @@ pub unsafe fn main() -> i32 {
     close(2);
     println!("[ERROR]I need fuzzy ...");
     open(
-        "编程是一件危险的事情",
+        "编程是一件危险的事情\0",
         OpenFlags::CREATE | OpenFlags::WRONLY,
     );
     set_priority(-7);
@@ -33,15 +33,15 @@ pub unsafe fn main() -> i32 {
     mail_write(100000, slice::from_raw_parts(0 as *const _, 53153));
     mail_write(133, &bug);
     mail_write(0, slice::from_raw_parts(0x1ff0 as *const _, 53153));
-    link("nonono", "yesyesyes");
-    link("fname0", "fname1");
-    link("fname1", "fname0");
-    link("fname0", "fname0");
-    link("\0", "fname1");
+    link("nonono\0", "yesyesyes\0");
+    link("fname0\0", "fname1\0");
+    link("fname1\0", "fname0\0");
+    link("fname0\0", "fname0\0");
+    link("\0", "fname1\0");
     let stat: *const Stat = 0 as *const _;
     ch8::raw_sys_fstat(0, stat);
     ch8::raw_sys_fstat(313, stat);
-    sys_unlinkat(555, "➑➑➑➑➑➑", 1);
-    sys_linkat(0, "QAQ", 7, "❆❆❆❆❆", 0);
+    sys_unlinkat(555, "➑➑➑➑➑➑\0", 1);
+    sys_linkat(0, "QAQ\0", 7, "❆❆❆❆❆\0", 0);
     0
 }

--- a/user/src/bin/ch8_05.rs
+++ b/user/src/bin/ch8_05.rs
@@ -12,6 +12,7 @@ fn heavy_fork_test() {
             let sleep_length = current_time * current_time % 1000 + 1000;
             sleep(sleep_length as usize);
         });
+        println!("Heavy fork test iteration {} success.", i);
     }
 }
 

--- a/user/src/bin/ch8_07.rs
+++ b/user/src/bin/ch8_07.rs
@@ -21,8 +21,10 @@ fn file_test0(idx: usize) {
 
 const NUM: usize = 65536;
 
-fn main() {
+#[no_mangle]
+pub fn main() -> i32 {
     for idx in 0..NUM {
         file_test0(idx);
     }
+    0
 }

--- a/user/src/bin/ch8_xx.rs
+++ b/user/src/bin/ch8_xx.rs
@@ -6,8 +6,10 @@ extern crate user_lib;
 use user_lib::ch8::*;
 use user_lib::{open, unlink, OpenFlags};
 
+#[allow(dead_code)]
 const SYSCALL_NUM: usize = 20;
 
+#[allow(dead_code)]
 const SYSCALL_IDS: [usize; SYSCALL_NUM] = [
     SYSCALL_OPENAT,       //  usize = 56;
     SYSCALL_CLOSE,        //  usize = 57;
@@ -31,10 +33,13 @@ const SYSCALL_IDS: [usize; SYSCALL_NUM] = [
     SYSCALL_MAIL_WRITE,   //  usize = 402;
 ];
 
+#[allow(dead_code)]
 fn rand_syscall_id() -> usize {
     0
 }
 
-fn main() {
+#[no_mangle]
+pub fn main() -> i32 {
     // TODO: a naive fuzzy
+    0
 }

--- a/user/src/ch8.rs
+++ b/user/src/ch8.rs
@@ -16,21 +16,23 @@ where
     F: FnOnce(usize),
 {
     let n: usize = 200;
+    let mut cnt = 0;    // 统计 fork 成功的次数
     for idx in 0..n {
         let pid = fork();
         if pid == 0 {
             func(idx);
             exit(0);
+        } else if pid > 0 {
+            cnt += 1;
         }
     }
     let mut exit_code: i32 = 0;
-    for _ in 0..n {
+    for _ in 0..cnt {
         assert!(wait(&mut exit_code) > 0);
         assert_eq!(exit_code, 0);
     }
     assert!(wait(&mut exit_code) < 0);
 }
-
 pub fn get_pc() -> usize {
     let mut ra: usize;
     unsafe {

--- a/user/src/lib.rs
+++ b/user/src/lib.rs
@@ -225,3 +225,6 @@ pub fn munmap(start: usize, len: usize) -> isize {
 pub fn spawn(path: &str) -> isize {
     sys_spawn(path)
 }
+
+pub fn dup(fd: usize) -> isize { sys_dup(fd) }
+pub fn pipe(pipe_fd: &mut [usize]) -> isize { sys_pipe(pipe_fd) }

--- a/user/src/syscall.rs
+++ b/user/src/syscall.rs
@@ -20,6 +20,8 @@ pub const SYSCALL_MMAP: usize = 222;
 pub const SYSCALL_SPAWN: usize = 400;
 pub const SYSCALL_MAIL_READ: usize = 401;
 pub const SYSCALL_MAIL_WRITE: usize = 402;
+pub const SYSCALL_DUP: usize = 24;
+pub const SYSCALL_PIPE: usize = 59;
 
 pub fn syscall(id: usize, args: [usize; 3]) -> isize {
     let mut ret: isize;
@@ -162,4 +164,12 @@ pub fn sys_munmap(start: usize, len: usize) -> isize {
 
 pub fn sys_spawn(path: &str) -> isize {
     syscall(SYSCALL_SPAWN, [path.as_ptr() as usize, 0, 0])
+}
+
+pub fn sys_dup(fd: usize) -> isize {
+    syscall(SYSCALL_DUP, [fd, 0, 0])
+}
+
+pub fn sys_pipe(pipe: &mut [usize]) -> isize {
+    syscall(SYSCALL_PIPE, [pipe.as_mut_ptr() as usize, 0, 0])
 }


### PR DESCRIPTION
修复了 ch8 测例中的如下问题，某些改动可能有争议，请检查后再 merge
- bug fix: 向 `ch8_03` `ch8_04` 中文件名参数后增加 `\0`
- bug fix: 修改 `ch8_07` `ch8_xx` 的 `main` 函数，添加 `#[no_mangle]` 标记
- logic fix: 修改 `ch8.rs` 中等待子进程的个数为成功创建的子进程数量
- `ch8_05` 等待的时间过长，在每次迭代后打印提示信息。

增加了 dup/pipe 两个系统调用的接口。

减少了一些无关紧要的 warning.