### PR TITLE
ch8_02中UNUSED_START已经被映射过了

### DIFF
--- a/user/src/bin/ch8_02.rs
+++ b/user/src/bin/ch8_02.rs
@@ -6,7 +6,7 @@ extern crate user_lib;
 
 use user_lib::mmap;
 
-const UNUSED_START: usize = 0x8000;
+const UNUSED_START: usize = 0x10000;
 const N: usize = 0x800;
 const LEN: usize = 0x10000;
 


### PR DESCRIPTION
对于ch8_02:

![image](https://user-images.githubusercontent.com/49710099/117421316-040b6700-af51-11eb-97ce-163d5c15e6ec.png)

上图是解析elf得到的需要映射的地址范围，已经包括了`UNUSED_START`(0x8000)