### PR TITLE
fix a bug in usershell when spawn fail

### DIFF
--- a/user/src/bin/ch5_usershell.rs
+++ b/user/src/bin/ch5_usershell.rs
@@ -33,6 +33,9 @@ pub fn main() -> i32 {
                     let cpid = spawn(line.as_str());
                     if cpid < 0 {
                         println!("invalid file name");
+                        line.clear();
+                        print!(">> ");
+                        flush();
                         continue;
                     }
                     let mut xstate: i32 = 0;


### PR DESCRIPTION
修复了 shell 中的如下 bug：spawn 失败后没有清空 line，导致后续输入的文件名都错误。